### PR TITLE
Add multilingual blog skeleton

### DIFF
--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+
+class BlogController extends Controller
+{
+    public function index()
+    {
+        $posts = Post::where('published', true)->with('translations')->get();
+
+        return view('blog.index', compact('posts'));
+    }
+}

--- a/app/Http/Controllers/CategoryController.php
+++ b/app/Http/Controllers/CategoryController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Category;
+
+class CategoryController extends Controller
+{
+    public function show(string $slug)
+    {
+        $category = Category::whereTranslation('slug', $slug)->firstOrFail();
+        $posts = $category->posts()->where('published', true)->with('translations')->get();
+
+        return view('blog.category', compact('category', 'posts'));
+    }
+}

--- a/app/Http/Controllers/PostController.php
+++ b/app/Http/Controllers/PostController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Post;
+
+class PostController extends Controller
+{
+    public function show(string $slug)
+    {
+        $post = Post::whereTranslation('slug', $slug)->where('published', true)->with(['category', 'tags'])->firstOrFail();
+
+        return view('blog.post', compact('post'));
+    }
+}

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Tag;
+
+class TagController extends Controller
+{
+    public function show(string $slug)
+    {
+        $tag = Tag::whereTranslation('slug', $slug)->firstOrFail();
+        $posts = $tag->posts()->where('published', true)->with('translations')->get();
+
+        return view('blog.tag', compact('tag', 'posts'));
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Astrotomic\Translatable\Translatable;
+
+class Category extends Model
+{
+    use Translatable;
+
+    protected $fillable = [
+        'published',
+    ];
+
+    public $translatedAttributes = [
+        'title',
+        'description',
+        'slug',
+    ];
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
+}

--- a/app/Models/CategoryTranslation.php
+++ b/app/Models/CategoryTranslation.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class CategoryTranslation extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'title',
+        'description',
+        'slug',
+    ];
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Astrotomic\Translatable\Translatable;
+
+class Post extends Model
+{
+    use Translatable;
+
+    protected $fillable = [
+        'category_id',
+        'published',
+    ];
+
+    public $translatedAttributes = [
+        'title',
+        'description',
+        'slug',
+    ];
+
+    public function category()
+    {
+        return $this->belongsTo(Category::class);
+    }
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class);
+    }
+}

--- a/app/Models/PostTranslation.php
+++ b/app/Models/PostTranslation.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PostTranslation extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'title',
+        'description',
+        'slug',
+    ];
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Astrotomic\Translatable\Translatable;
+
+class Tag extends Model
+{
+    use Translatable;
+
+    protected $fillable = [];
+
+    public $translatedAttributes = [
+        'title',
+        'description',
+        'slug',
+    ];
+
+    public function posts()
+    {
+        return $this->belongsToMany(Post::class);
+    }
+}

--- a/app/Models/TagTranslation.php
+++ b/app/Models/TagTranslation.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TagTranslation extends Model
+{
+    public $timestamps = false;
+
+    protected $fillable = [
+        'title',
+        'description',
+        'slug',
+    ];
+}

--- a/config/laravellocalization.php
+++ b/config/laravellocalization.php
@@ -1,0 +1,24 @@
+<?php
+
+return [
+    'supportedLocales' => [
+        'en' => [
+            'name' => 'English',
+            'script' => 'Latn',
+            'native' => 'English',
+        ],
+        'es' => [
+            'name' => 'Spanish',
+            'script' => 'Latn',
+            'native' => 'Español',
+        ],
+        'ru' => [
+            'name' => 'Russian',
+            'script' => 'Cyrl',
+            'native' => 'Русский',
+        ],
+    ],
+
+    // Do not add locale prefix for the default language
+    'hideDefaultLocaleInURL' => true,
+];

--- a/database/migrations/2024_01_01_000100_create_blog_tables.php
+++ b/database/migrations/2024_01_01_000100_create_blog_tables.php
@@ -1,0 +1,76 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            $table->id();
+            $table->boolean('published')->default(false);
+            $table->timestamps();
+        });
+
+        Schema::create('category_translations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('category_id')->constrained()->cascadeOnDelete();
+            $table->string('locale')->index();
+            $table->string('title')->nullable();
+            $table->text('description')->nullable();
+            $table->string('slug')->unique();
+            $table->unique(['category_id', 'locale']);
+        });
+
+        Schema::create('tags', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+
+        Schema::create('tag_translations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tag_id')->constrained()->cascadeOnDelete();
+            $table->string('locale')->index();
+            $table->string('title')->nullable();
+            $table->text('description')->nullable();
+            $table->string('slug')->unique();
+            $table->unique(['tag_id', 'locale']);
+        });
+
+        Schema::create('posts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('category_id')->nullable()->constrained()->nullOnDelete();
+            $table->boolean('published')->default(false);
+            $table->timestamps();
+        });
+
+        Schema::create('post_translations', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->string('locale')->index();
+            $table->string('title')->nullable();
+            $table->text('description')->nullable();
+            $table->string('slug')->unique();
+            $table->unique(['post_id', 'locale']);
+        });
+
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->foreignId('post_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('tag_id')->constrained()->cascadeOnDelete();
+            $table->primary(['post_id', 'tag_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('post_tag');
+        Schema::dropIfExists('post_translations');
+        Schema::dropIfExists('posts');
+        Schema::dropIfExists('tag_translations');
+        Schema::dropIfExists('tags');
+        Schema::dropIfExists('category_translations');
+        Schema::dropIfExists('categories');
+    }
+};

--- a/resources/views/blog/category.blade.php
+++ b/resources/views/blog/category.blade.php
@@ -1,0 +1,7 @@
+<h1>{{ $category->title }}</h1>
+<p>{!! $category->description !!}</p>
+<ul>
+@foreach($posts as $post)
+    <li><a href="{{ route('blog.post', ['slug' => $post->slug]) }}">{{ $post->title }}</a></li>
+@endforeach
+</ul>

--- a/resources/views/blog/index.blade.php
+++ b/resources/views/blog/index.blade.php
@@ -1,0 +1,6 @@
+<h1>Blog</h1>
+<ul>
+@foreach($posts as $post)
+    <li><a href="{{ route('blog.post', ['slug' => $post->slug]) }}">{{ $post->title }}</a></li>
+@endforeach
+</ul>

--- a/resources/views/blog/post.blade.php
+++ b/resources/views/blog/post.blade.php
@@ -1,0 +1,12 @@
+<h1>{{ $post->title }}</h1>
+<p>{!! $post->description !!}</p>
+@if($post->category)
+    <p>Category: <a href="{{ route('blog.category', ['slug' => $post->category->slug]) }}">{{ $post->category->title }}</a></p>
+@endif
+@if($post->tags->isNotEmpty())
+    <ul>
+    @foreach($post->tags as $tag)
+        <li><a href="{{ route('blog.tag', ['slug' => $tag->slug]) }}">{{ $tag->title }}</a></li>
+    @endforeach
+    </ul>
+@endif

--- a/resources/views/blog/tag.blade.php
+++ b/resources/views/blog/tag.blade.php
@@ -1,0 +1,7 @@
+<h1>{{ $tag->title }}</h1>
+<p>{!! $tag->description !!}</p>
+<ul>
+@foreach($posts as $post)
+    <li><a href="{{ route('blog.post', ['slug' => $post->slug]) }}">{{ $post->title }}</a></li>
+@endforeach
+</ul>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,3 +5,21 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+use Mcamara\LaravelLocalization\Facades\LaravelLocalization;
+use App\Http\Controllers\BlogController;
+use App\Http\Controllers\PostController;
+use App\Http\Controllers\CategoryController;
+use App\Http\Controllers\TagController;
+
+Route::group([
+    'prefix' => LaravelLocalization::setLocale(),
+    'middleware' => ['localeSessionRedirect', 'localizationRedirect', 'localeViewPath']
+], function () {
+    Route::prefix('blog')->group(function () {
+        Route::get('/', [BlogController::class, 'index'])->name('blog.index');
+        Route::get('/category/{slug}', [CategoryController::class, 'show'])->name('blog.category');
+        Route::get('/tag/{slug}', [TagController::class, 'show'])->name('blog.tag');
+        Route::get('/{slug}', [PostController::class, 'show'])->name('blog.post');
+    });
+});


### PR DESCRIPTION
## Summary
- set up localization config for English, Spanish and Russian without default prefix
- scaffold posts, categories and tags with translation tables
- add localized blog routes and simple controllers/views

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f102dbc88324bda68004fbe3170d