### PR TITLE
Add multilingual blog with Twill modules

### DIFF
--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Repositories\PostRepository;
+use App\Repositories\CategoryRepository;
+use App\Repositories\TagRepository;
+use Illuminate\View\View;
+
+class BlogController extends Controller
+{
+    public function index(PostRepository $posts): View
+    {
+        $items = $posts->published()->get();
+        return view('site.blog.index', ['posts' => $items]);
+    }
+
+    public function post(string $slug, PostRepository $posts): View
+    {
+        $post = $posts->forSlug($slug);
+        abort_unless($post, 404);
+        return view('site.blog.post', ['item' => $post]);
+    }
+
+    public function category(string $slug, CategoryRepository $categories, PostRepository $posts): View
+    {
+        $category = $categories->forSlug($slug);
+        abort_unless($category, 404);
+        $items = $posts->published()->where('category_id', $category->id)->get();
+        return view('site.blog.category', ['category' => $category, 'posts' => $items]);
+    }
+
+    public function tag(string $slug, TagRepository $tags, PostRepository $posts): View
+    {
+        $tag = $tags->forSlug($slug);
+        abort_unless($tag, 404);
+        $items = $posts->published()->whereHas('tags', function ($q) use ($tag) {
+            $q->where('tags.id', $tag->id);
+        })->get();
+        return view('site.blog.tag', ['tag' => $tag, 'posts' => $items]);
+    }
+}

--- a/app/Http/Controllers/Twill/CategoryController.php
+++ b/app/Http/Controllers/Twill/CategoryController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Twill;
+
+use A17\Twill\Models\Contracts\TwillModelContract;
+use A17\Twill\Services\Forms\Fields\Wysiwyg;
+use A17\Twill\Services\Forms\Form;
+use A17\Twill\Http\Controllers\Admin\ModuleController as BaseModuleController;
+
+class CategoryController extends BaseModuleController
+{
+    protected $moduleName = 'categories';
+
+    public function getForm(TwillModelContract $model): Form
+    {
+        $form = parent::getForm($model);
+
+        $form->add(
+            Wysiwyg::make()->name('description')->label('Description')->translatable()
+        );
+
+        return $form;
+    }
+}

--- a/app/Http/Controllers/Twill/PostController.php
+++ b/app/Http/Controllers/Twill/PostController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers\Twill;
+
+use A17\Twill\Models\Contracts\TwillModelContract;
+use A17\Twill\Services\Forms\Fields\Wysiwyg;
+use A17\Twill\Services\Forms\Fields\Browser;
+use A17\Twill\Services\Forms\Form;
+use A17\Twill\Http\Controllers\Admin\ModuleController as BaseModuleController;
+
+class PostController extends BaseModuleController
+{
+    protected $moduleName = 'posts';
+
+    public function getForm(TwillModelContract $model): Form
+    {
+        $form = parent::getForm($model);
+
+        $form->add(
+            Wysiwyg::make()->name('description')->label('Description')->translatable()
+        );
+
+        $form->add(
+            Browser::make()->name('category')->module('categories')->max(1)
+        );
+
+        $form->add(
+            Browser::make()->name('tags')->module('tags')
+        );
+
+        return $form;
+    }
+}

--- a/app/Http/Controllers/Twill/TagController.php
+++ b/app/Http/Controllers/Twill/TagController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Twill;
+
+use A17\Twill\Models\Contracts\TwillModelContract;
+use A17\Twill\Services\Forms\Fields\Wysiwyg;
+use A17\Twill\Services\Forms\Form;
+use A17\Twill\Http\Controllers\Admin\ModuleController as BaseModuleController;
+
+class TagController extends BaseModuleController
+{
+    protected $moduleName = 'tags';
+
+    public function getForm(TwillModelContract $model): Form
+    {
+        $form = parent::getForm($model);
+
+        $form->add(
+            Wysiwyg::make()->name('description')->label('Description')->translatable()
+        );
+
+        return $form;
+    }
+}

--- a/app/Http/Requests/Twill/CategoryRequest.php
+++ b/app/Http/Requests/Twill/CategoryRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests\Twill;
+
+use A17\Twill\Http\Requests\Admin\Request;
+
+class CategoryRequest extends Request
+{
+    public function rulesForCreate()
+    {
+        return [];
+    }
+
+    public function rulesForUpdate()
+    {
+        return [];
+    }
+}

--- a/app/Http/Requests/Twill/PostRequest.php
+++ b/app/Http/Requests/Twill/PostRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests\Twill;
+
+use A17\Twill\Http\Requests\Admin\Request;
+
+class PostRequest extends Request
+{
+    public function rulesForCreate()
+    {
+        return [];
+    }
+
+    public function rulesForUpdate()
+    {
+        return [];
+    }
+}

--- a/app/Http/Requests/Twill/TagRequest.php
+++ b/app/Http/Requests/Twill/TagRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Requests\Twill;
+
+use A17\Twill\Http\Requests\Admin\Request;
+
+class TagRequest extends Request
+{
+    public function rulesForCreate()
+    {
+        return [];
+    }
+
+    public function rulesForUpdate()
+    {
+        return [];
+    }
+}

--- a/app/Models/Category.php
+++ b/app/Models/Category.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use A17\Twill\Models\Behaviors\HasTranslation;
+use A17\Twill\Models\Behaviors\HasSlug;
+use A17\Twill\Models\Behaviors\HasRevisions;
+use A17\Twill\Models\Model;
+
+class Category extends Model
+{
+    use HasTranslation, HasSlug, HasRevisions;
+
+    protected $fillable = [
+        'published',
+        'title',
+        'description',
+    ];
+
+    public $translatedAttributes = [
+        'title',
+        'description',
+    ];
+
+    public $slugAttributes = [
+        'title',
+    ];
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
+    }
+}

--- a/app/Models/Post.php
+++ b/app/Models/Post.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use A17\Twill\Models\Behaviors\HasTranslation;
+use A17\Twill\Models\Behaviors\HasSlug;
+use A17\Twill\Models\Behaviors\HasRevisions;
+use A17\Twill\Models\Model;
+
+class Post extends Model
+{
+    use HasTranslation, HasSlug, HasRevisions;
+
+    protected $fillable = [
+        'published',
+        'title',
+        'description',
+        'category_id',
+    ];
+
+    public $translatedAttributes = [
+        'title',
+        'description',
+    ];
+
+    public $slugAttributes = [
+        'title',
+    ];
+
+    public function category()
+    {
+        return $this->belongsTo(Category::class);
+    }
+
+    public function tags()
+    {
+        return $this->belongsToMany(Tag::class);
+    }
+}

--- a/app/Models/Revisions/CategoryRevision.php
+++ b/app/Models/Revisions/CategoryRevision.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models\Revisions;
+
+use A17\Twill\Models\Revision;
+
+class CategoryRevision extends Revision
+{
+    protected $table = 'category_revisions';
+}

--- a/app/Models/Revisions/PostRevision.php
+++ b/app/Models/Revisions/PostRevision.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models\Revisions;
+
+use A17\Twill\Models\Revision;
+
+class PostRevision extends Revision
+{
+    protected $table = 'post_revisions';
+}

--- a/app/Models/Revisions/TagRevision.php
+++ b/app/Models/Revisions/TagRevision.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models\Revisions;
+
+use A17\Twill\Models\Revision;
+
+class TagRevision extends Revision
+{
+    protected $table = 'tag_revisions';
+}

--- a/app/Models/Slugs/CategorySlug.php
+++ b/app/Models/Slugs/CategorySlug.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models\Slugs;
+
+use A17\Twill\Models\Model;
+
+class CategorySlug extends Model
+{
+    protected $table = 'category_slugs';
+}

--- a/app/Models/Slugs/PostSlug.php
+++ b/app/Models/Slugs/PostSlug.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models\Slugs;
+
+use A17\Twill\Models\Model;
+
+class PostSlug extends Model
+{
+    protected $table = 'post_slugs';
+}

--- a/app/Models/Slugs/TagSlug.php
+++ b/app/Models/Slugs/TagSlug.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Models\Slugs;
+
+use A17\Twill\Models\Model;
+
+class TagSlug extends Model
+{
+    protected $table = 'tag_slugs';
+}

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use A17\Twill\Models\Behaviors\HasTranslation;
+use A17\Twill\Models\Behaviors\HasSlug;
+use A17\Twill\Models\Behaviors\HasRevisions;
+use A17\Twill\Models\Model;
+
+class Tag extends Model
+{
+    use HasTranslation, HasSlug, HasRevisions;
+
+    protected $fillable = [
+        'published',
+        'title',
+        'description',
+    ];
+
+    public $translatedAttributes = [
+        'title',
+        'description',
+    ];
+
+    public $slugAttributes = [
+        'title',
+    ];
+
+    public function posts()
+    {
+        return $this->belongsToMany(Post::class);
+    }
+}

--- a/app/Models/Translations/CategoryTranslation.php
+++ b/app/Models/Translations/CategoryTranslation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models\Translations;
+
+use A17\Twill\Models\Model;
+use App\Models\Category;
+
+class CategoryTranslation extends Model
+{
+    protected $baseModuleModel = Category::class;
+}

--- a/app/Models/Translations/PostTranslation.php
+++ b/app/Models/Translations/PostTranslation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models\Translations;
+
+use A17\Twill\Models\Model;
+use App\Models\Post;
+
+class PostTranslation extends Model
+{
+    protected $baseModuleModel = Post::class;
+}

--- a/app/Models/Translations/TagTranslation.php
+++ b/app/Models/Translations/TagTranslation.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models\Translations;
+
+use A17\Twill\Models\Model;
+use App\Models\Tag;
+
+class TagTranslation extends Model
+{
+    protected $baseModuleModel = Tag::class;
+}

--- a/app/Repositories/CategoryRepository.php
+++ b/app/Repositories/CategoryRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Repositories;
+
+use A17\Twill\Repositories\Behaviors\HandleTranslations;
+use A17\Twill\Repositories\Behaviors\HandleSlugs;
+use A17\Twill\Repositories\Behaviors\HandleRevisions;
+use A17\Twill\Repositories\ModuleRepository;
+use App\Models\Category;
+
+class CategoryRepository extends ModuleRepository
+{
+    use HandleTranslations, HandleSlugs, HandleRevisions;
+
+    public function __construct(Category $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/app/Repositories/PostRepository.php
+++ b/app/Repositories/PostRepository.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Repositories;
+
+use A17\Twill\Repositories\Behaviors\HandleTranslations;
+use A17\Twill\Repositories\Behaviors\HandleSlugs;
+use A17\Twill\Repositories\Behaviors\HandleRevisions;
+use A17\Twill\Repositories\ModuleRepository;
+use App\Models\Post;
+
+class PostRepository extends ModuleRepository
+{
+    use HandleTranslations, HandleSlugs, HandleRevisions;
+
+    protected array $relatedBrowsers = ['category', 'tags'];
+
+    public function __construct(Post $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/app/Repositories/TagRepository.php
+++ b/app/Repositories/TagRepository.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Repositories;
+
+use A17\Twill\Repositories\Behaviors\HandleTranslations;
+use A17\Twill\Repositories\Behaviors\HandleSlugs;
+use A17\Twill\Repositories\Behaviors\HandleRevisions;
+use A17\Twill\Repositories\ModuleRepository;
+use App\Models\Tag;
+
+class TagRepository extends ModuleRepository
+{
+    use HandleTranslations, HandleSlugs, HandleRevisions;
+
+    public function __construct(Tag $model)
+    {
+        $this->model = $model;
+    }
+}

--- a/config/laravellocalization.php
+++ b/config/laravellocalization.php
@@ -48,6 +48,7 @@ return [
         //'en-CA'       => ['name' => 'Canadian English',       'script' => 'Latn', 'native' => 'Canadian English', 'regional' => 'en_CA'],
         //'en-US'       => ['name' => 'U.S. English',           'script' => 'Latn', 'native' => 'U.S. English', 'regional' => 'en_US'],
         'es'          => ['name' => 'Spanish',                'script' => 'Latn', 'native' => 'español', 'regional' => 'es_ES'],
+        'ru'          => ['name' => 'Russian',                'script' => 'Cyrl', 'native' => 'Русский', 'regional' => 'ru_RU'],
         //'eo'          => ['name' => 'Esperanto',              'script' => 'Latn', 'native' => 'esperanto', 'regional' => ''],
         //'eu'          => ['name' => 'Basque',                 'script' => 'Latn', 'native' => 'euskara', 'regional' => 'eu_ES'],
         //'ewo'         => ['name' => 'Ewondo',                 'script' => 'Latn', 'native' => 'ewondo', 'regional' => ''],

--- a/config/twill.php
+++ b/config/twill.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'admin_app_path' => 'cms',
     'block_editor' => [
         'use_twill_blocks' => [],
         'crops' => [

--- a/database/migrations/2024_09_28_100000_create_categories_tables.php
+++ b/database/migrations/2024_09_28_100000_create_categories_tables.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('categories', function (Blueprint $table) {
+            createDefaultTableFields($table);
+        });
+
+        Schema::create('category_translations', function (Blueprint $table) {
+            createDefaultTranslationsTableFields($table, 'category');
+            $table->string('title', 200)->nullable();
+            $table->text('description')->nullable();
+        });
+
+        Schema::create('category_slugs', function (Blueprint $table) {
+            createDefaultSlugsTableFields($table, 'category');
+        });
+
+        Schema::create('category_revisions', function (Blueprint $table) {
+            createDefaultRevisionsTableFields($table, 'category');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('category_revisions');
+        Schema::dropIfExists('category_translations');
+        Schema::dropIfExists('category_slugs');
+        Schema::dropIfExists('categories');
+    }
+};

--- a/database/migrations/2024_09_28_100100_create_tags_tables.php
+++ b/database/migrations/2024_09_28_100100_create_tags_tables.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('tags', function (Blueprint $table) {
+            createDefaultTableFields($table);
+        });
+
+        Schema::create('tag_translations', function (Blueprint $table) {
+            createDefaultTranslationsTableFields($table, 'tag');
+            $table->string('title', 200)->nullable();
+            $table->text('description')->nullable();
+        });
+
+        Schema::create('tag_slugs', function (Blueprint $table) {
+            createDefaultSlugsTableFields($table, 'tag');
+        });
+
+        Schema::create('tag_revisions', function (Blueprint $table) {
+            createDefaultRevisionsTableFields($table, 'tag');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tag_revisions');
+        Schema::dropIfExists('tag_translations');
+        Schema::dropIfExists('tag_slugs');
+        Schema::dropIfExists('tags');
+    }
+};

--- a/database/migrations/2024_09_28_100200_create_posts_tables.php
+++ b/database/migrations/2024_09_28_100200_create_posts_tables.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('posts', function (Blueprint $table) {
+            createDefaultTableFields($table);
+            $table->foreignId('category_id')->nullable()->constrained('categories');
+        });
+
+        Schema::create('post_translations', function (Blueprint $table) {
+            createDefaultTranslationsTableFields($table, 'post');
+            $table->string('title', 200)->nullable();
+            $table->text('description')->nullable();
+        });
+
+        Schema::create('post_slugs', function (Blueprint $table) {
+            createDefaultSlugsTableFields($table, 'post');
+        });
+
+        Schema::create('post_revisions', function (Blueprint $table) {
+            createDefaultRevisionsTableFields($table, 'post');
+        });
+
+        Schema::create('post_tag', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('post_id')->constrained()->onDelete('cascade');
+            $table->foreignId('tag_id')->constrained()->onDelete('cascade');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('post_tag');
+        Schema::dropIfExists('post_revisions');
+        Schema::dropIfExists('post_translations');
+        Schema::dropIfExists('post_slugs');
+        Schema::dropIfExists('posts');
+    }
+};

--- a/resources/views/site/blog/category.blade.php
+++ b/resources/views/site/blog/category.blade.php
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="{{ app()->getLocale() }}">
+<head>
+    <title>{{ $category->title }}</title>
+    @vite('resources/css/app.css')
+</head>
+<body>
+<x-menu/>
+<div class="mx-auto max-w-2xl px-5 md:px-0">
+    <div class="prose md:prose-lg lg:prose-xl prose-a:font-normal mt-16 first:mt-0">
+        <h1>{{ $category->title }}</h1>
+    </div>
+    <div class="prose md:prose-lg lg:prose-xl prose-a:font-normal mt-8">
+        {!! $category->description !!}
+    </div>
+    <ul class="mt-8 space-y-2">
+        @foreach($posts as $post)
+            <li><a href="{{ route('blog.post', $post->slug) }}">{{ $post->title }}</a></li>
+        @endforeach
+    </ul>
+</div>
+</body>
+</html>

--- a/resources/views/site/blog/index.blade.php
+++ b/resources/views/site/blog/index.blade.php
@@ -1,0 +1,18 @@
+<!doctype html>
+<html lang="{{ app()->getLocale() }}">
+<head>
+    <title>Blog</title>
+    @vite('resources/css/app.css')
+</head>
+<body>
+<x-menu/>
+<div class="mx-auto max-w-2xl px-5 md:px-0">
+    <h1 class="mt-16">{{ __('Blog') }}</h1>
+    <ul class="mt-8 space-y-2">
+        @foreach($posts as $post)
+            <li><a href="{{ route('blog.post', $post->slug) }}">{{ $post->title }}</a></li>
+        @endforeach
+    </ul>
+</div>
+</body>
+</html>

--- a/resources/views/site/blog/post.blade.php
+++ b/resources/views/site/blog/post.blade.php
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="{{ app()->getLocale() }}">
+<head>
+    <title>{{ $item->title }}</title>
+    @vite('resources/css/app.css')
+</head>
+<body>
+<x-menu/>
+<div class="mx-auto max-w-2xl px-5 md:px-0">
+    <div class="prose md:prose-lg lg:prose-xl prose-a:font-normal mt-16 first:mt-0">
+        <h1>{{ $item->title }}</h1>
+    </div>
+    <div class="prose md:prose-lg lg:prose-xl prose-a:font-normal mt-8">
+        {!! $item->description !!}
+    </div>
+    @if($item->category)
+        <p class="mt-8">{{ __('Category') }}: <a href="{{ route('blog.category', $item->category->slug) }}">{{ $item->category->title }}</a></p>
+    @endif
+    @if($item->tags->count())
+        <p class="mt-2">{{ __('Tags') }}:
+            @foreach($item->tags as $tag)
+                <a href="{{ route('blog.tag', $tag->slug) }}">{{ $tag->title }}</a>@if(!$loop->last), @endif
+            @endforeach
+        </p>
+    @endif
+</div>
+</body>
+</html>

--- a/resources/views/site/blog/tag.blade.php
+++ b/resources/views/site/blog/tag.blade.php
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="{{ app()->getLocale() }}">
+<head>
+    <title>{{ $tag->title }}</title>
+    @vite('resources/css/app.css')
+</head>
+<body>
+<x-menu/>
+<div class="mx-auto max-w-2xl px-5 md:px-0">
+    <div class="prose md:prose-lg lg:prose-xl prose-a:font-normal mt-16 first:mt-0">
+        <h1>{{ $tag->title }}</h1>
+    </div>
+    <div class="prose md:prose-lg lg:prose-xl prose-a:font-normal mt-8">
+        {!! $tag->description !!}
+    </div>
+    <ul class="mt-8 space-y-2">
+        @foreach($posts as $post)
+            <li><a href="{{ route('blog.post', $post->slug) }}">{{ $post->title }}</a></li>
+        @endforeach
+    </ul>
+</div>
+</body>
+</html>

--- a/routes/twill.php
+++ b/routes/twill.php
@@ -4,3 +4,6 @@ use A17\Twill\Facades\TwillRoutes;
 
 TwillRoutes::module('pages');
 TwillRoutes::module('menuLinks');
+TwillRoutes::module('categories');
+TwillRoutes::module('tags');
+TwillRoutes::module('posts');

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,8 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Mcamara\LaravelLocalization\Facades\LaravelLocalization;
+use App\Http\Controllers\BlogController;
 
 /*
 |--------------------------------------------------------------------------
@@ -13,5 +15,17 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::get('/', [\App\Http\Controllers\PageDisplayController::class, 'home'])->name('frontend.home');
-Route::get('{slug}', [\App\Http\Controllers\PageDisplayController::class, 'show'])->name('frontend.page');
+Route::group([
+    'prefix' => LaravelLocalization::setLocale(),
+    'middleware' => ['localeSessionRedirect', 'localizationRedirect', 'localeViewPath']
+], function () {
+    Route::prefix('blog')->group(function () {
+        Route::get('/', [BlogController::class, 'index'])->name('blog.index');
+        Route::get('category/{slug}', [BlogController::class, 'category'])->name('blog.category');
+        Route::get('tag/{slug}', [BlogController::class, 'tag'])->name('blog.tag');
+        Route::get('{slug}', [BlogController::class, 'post'])->name('blog.post');
+    });
+
+    Route::get('/', [\App\Http\Controllers\PageDisplayController::class, 'home'])->name('frontend.home');
+    Route::get('{slug}', [\App\Http\Controllers\PageDisplayController::class, 'show'])->name('frontend.page');
+});


### PR DESCRIPTION
## Summary
- set Twill admin to `/cms`
- add multilingual blog (posts, categories, tags) with localized routes
- scaffold blog views and repositories

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a7076aa5508324b72247c463a8be46